### PR TITLE
Fix generate demo

### DIFF
--- a/syntetic_data/date_text_generator.py
+++ b/syntetic_data/date_text_generator.py
@@ -143,7 +143,7 @@ class DateTextGenerator():
 
         return dataset
 
-    def generate_demo(self,date='01/01/2020'):
+    def generate_demo(self,date='01/01/2020',date_type='DD/MM/YYYY'):
         '''
             Generates a demo for all the text forms
             contained in the model for a given date.
@@ -151,15 +151,15 @@ class DateTextGenerator():
         methods = []
         generated_texts = []
 
-        day,month, year = date.split('/')
+        day,month, year = self.parse_days_months_years(date,date_type)
 
-        for method_id,date_text_gen_method in self.absolute_date_text_gen_methods.items():
+        for method_id,date_text_gen_method in self.date_text_gen_methods[date_type].items():
         
             methods.append(method_id)
             generated_texts.append(date_text_gen_method(day,month,year))
 
 
-        dataset = pd.DataFrame(list(zip(methods,generated_texts,[date]*len(self.absolute_date_text_gen_methods))),
+        dataset = pd.DataFrame(list(zip(methods,generated_texts,[date]*len(self.date_text_gen_methods[date_type]))),
             columns=['Input Pattern','Generated Text','Origin Sample'])
 
         return dataset

--- a/syntetic_data/relative_date_text_generator.py
+++ b/syntetic_data/relative_date_text_generator.py
@@ -131,23 +131,23 @@ class RelativeDateTextGenerator(DateTextGenerator):
 
         return dataset
 
-    def generate_demo(self,sample=13):
+    def generate_demo(self,n=13):
         '''
             Generates a demo for all the text forms
-            contained in the model for a given date.
+            contained in the model for a given number n.
         '''        
         methods = []
         generated_texts = []
+        targets = []
 
-        day,month, year = date.split('/')
-
-        for method_id,date_text_gen_method in self.absolute_date_text_gen_methods.items():
+        for method_id,date_text_gen_method in self.date_text_gen_methods['Relative'].items():
         
             methods.append(method_id)
-            generated_texts.append(date_text_gen_method(day,month,year))
+            sample,target = date_text_gen_method(n)
+            generated_texts.append(sample)
+            targets.append(target)
 
-
-        dataset = pd.DataFrame(list(zip(methods,generated_texts,[date]*len(self.absolute_date_text_gen_methods))),
+        dataset = pd.DataFrame(list(zip(methods,generated_texts,targets)),
             columns=['Input Pattern','Generated Text','Origin Sample'])
 
         return dataset


### PR DESCRIPTION
Fixing the generate demo method for all date formats.

usage example below:

```python
from random import random

from syntetic_data import DateTextGenerator
from syntetic_data import RelativeDateTextGenerator

from collections import OrderedDict

a = DateTextGenerator(start_date='01/01/1906',end_date='01/01/2008',
 text_noise_rate=0.3,max_noise_occurences_per_sample=3,
 language='en',occurences_per_sample_dict= OrderedDict([
     ('DD/MM/YYYY',1),
     ('DD/MM',3),
    ('MM/YYYY',10)
 ]))

print(a.generate_demo('12/1995','MM/YYYY'))

a = RelativeDateTextGenerator(n_samples=1000,max_noise_occurences_per_sample=2,
    text_noise_rate=0.3,samples_per_method=10,language='pt')

print(a.generate_demo())
```